### PR TITLE
Upgrade UUID to Address Deprecation Warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,6 @@
   "dependencies": {
     "object-hash": "^1.1.2",
     "stack-trace": "0.0.9",
-    "uuid": "^3.0.0"
+    "uuid": "9.0.1"
   }
 }


### PR DESCRIPTION
Address this warning when installing `newman`

```
npm WARN deprecated uuid@3.4.0: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See h
ttps://v8.dev/blog/math-random for details.
```